### PR TITLE
fix: add priority attribute on img to avoid layout shift

### DIFF
--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -56,6 +56,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         alt={alt}
         width={500}
         height={500}
+        priority
       />
     ),
     ...components,


### PR DESCRIPTION
priority attribute on img to avoid layout shift